### PR TITLE
Fix Deprecation Warning on Load

### DIFF
--- a/src/GeneticAlgorithms.jl
+++ b/src/GeneticAlgorithms.jl
@@ -155,7 +155,7 @@ function crossover_population(model::GAmodel, groupings)
     model.gen_num += 1
 
     for group in groupings
-        parents = { old_pop[i] for i in group }
+        parents = Any[ old_pop[i] for i in group ]
         entity = model.ga.crossover(parents)
 
         push!(model.population, entity)


### PR DESCRIPTION
-- ISSUE

The following deprecation warning happens on loading the library:

> WARNING: deprecated syntax "{a for a in b}" at
> `../.julia/v0.4/GeneticAlgorithms/src/GeneticAlgorithms.jl:158.`
> Use "Any[a for a in b]" instead.

-- FIX

Replace with proper syntax.